### PR TITLE
Asking for the License Plate as part of the input information

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ On the command line, run
 The script will ask you for the name of the account you are checking. The AWS credentials must be associated to this account. By default it will use 
     *BCGOV_MASTER_admin_tmhl5tvs*
 
-Please, keep the format of the account name as BCGOV_<Type>_<Role>_<LicensePlate>, this allows to better classify and keep track of the records.
+Please, keep the format of the account name as BCGOV_Type_Role_LicensePlate, this allows to better classify and keep track of the records.
 - Values for **Type** are: *CORE*, *WORKLOAD*, *MASTER*
 - Values for **Role** are : *Admin*, *billing*, *developer*, *readonly*, *security*
 
@@ -65,9 +65,9 @@ To compare two snapshots you run the
 script. It assumes you are comparing snapshots associated to the same account and the same Landing Zone, otherwise the script will stop
 
 When you start the script it ask if the files are stored in a folder other than ./results and/or the file names do not follow the standard form described above.
-Enter y if you want to enter non-standard location/names for the files. It will ask first the name of the older file to compare with the newer one.
+Enter **y** if you want to enter non-standard location/names for the files. It will ask first the name of the older file to compare with the newer one.
 
-If you enter a key other than y it will ask you the following questions:
+If you enter a key other than **y** it will ask you the following questions:
 - Account name, but default will use *BCGOV_MASTER_admin_tmhl5tvs*
 - Number of the Landing Zone
 - Date in which the older snapshot was taken in *YYYMMDD* format
@@ -75,6 +75,6 @@ If you enter a key other than y it will ask you the following questions:
 
 The script will parse the account name and try to find the corresponding json files in the *./results* directory. If it fails I will display a message and the program will end.
 
-Currently the comparison file is saved in the same folder where the script is running with the format ***yyyymmdd_YYYMMDD_<Type><Role>LZ#.html***
+Currently the comparison file is saved in the same folder where the script is running with the format ***yyyymmdd_YYYMMDD_TypeRoleLZ#.html***
 
 where *yyyymmdd* is the date for the older snapshot, *YYYYMMDD* is the date for the newer snapshot, *Type* and *Role* are the values extracted from the account name, and *#* is the Landing Zone number.

--- a/aws_ConfigValues.py
+++ b/aws_ConfigValues.py
@@ -13,7 +13,7 @@ from os.path import exists
 #  AWS_DEFAULT_REGION
 
 
-def awsConfigValues(awsAccountUsed,resultsFile,LZ):
+def awsConfigValues(awsAccountUsed,LicensePlate,resultsFile,LZ):
     suppFunct.checkExistCreate(resultsFile)
 
     ############################################################################################
@@ -188,6 +188,6 @@ def awsConfigValues(awsAccountUsed,resultsFile,LZ):
     suppFunct.delFile('./apiResults.txt')
     suppFunct.delFile('./apiResults.json')
 
-    suppFunct.closeResultsFile(resultsFile,awsAccountUsed,LZ)
+    suppFunct.closeResultsFile(resultsFile,LicensePlate,awsAccountUsed,LZ)
 
     convertToHTML.convertKeyParam(resultsFile,LZ)

--- a/aws_PoliciesInRoles.py
+++ b/aws_PoliciesInRoles.py
@@ -14,7 +14,7 @@ from os.path import exists
 #  AWS_DEFAULT_REGION
 
 
-def awsPoliciesInRoles(awsAccountUsed,resultsFile,LZ):
+def awsPoliciesInRoles(awsAccountUsed,LicensePlate,resultsFile,LZ):
     suppFunct.checkExistCreate(resultsFile)
 
     ############################################################################################
@@ -89,7 +89,7 @@ def awsPoliciesInRoles(awsAccountUsed,resultsFile,LZ):
     suppFunct.delFile('./apiResults.json')
 
 
-    suppFunct.closeResultsFile(resultsFile,awsAccountUsed,LZ)
+    suppFunct.closeResultsFile(resultsFile,LicensePlate,awsAccountUsed,LZ)
 
     convertToHTML.convertPoliciesRoles(resultsFile,LZ)
 

--- a/compareGuardrails.py
+++ b/compareGuardrails.py
@@ -72,7 +72,12 @@ else: # Case we search in the ./results folder and the files names follow the st
             userAccount="BCGOV_MASTER_admin_tmhl5tvs"
         userAccountSplit=userAccount.split("_")
 
-
+    LicensePlate=""
+    print("Which License Plate-environment is using the previous base account? - If enter nothing will use  \"tmhl5tvs-dev\"")
+    LicensePlate=input()
+    if len(LicensePlate)==0:
+        userAccount="tmhl5tvs-dev"
+    
     LZ=""
     while LZ not in ["0","1","2"]:
         print('Which Landing zone LZ are you using 0/1/2')
@@ -95,11 +100,11 @@ else: # Case we search in the ./results folder and the files names follow the st
         print('Enter the date of the newer snapshot as YYYYMMDD')
         newerDate=input()  
    
-    olderSnapshotConfig=olderDate+ "_" + type + role + "ConfigLZ" + LZ + ".json"
-    newerSnapshotConfig=newerDate+ "_" + type + role + "ConfigLZ" + LZ + ".json"
+    olderSnapshotConfig=olderDate+ "_" + type + role + "Config" + "_" + LicensePlate + "_LZ" + LZ + ".json"
+    newerSnapshotConfig=newerDate+ "_" + type + role + "Config" + "_" + LicensePlate + "_LZ" +  LZ + ".json"
  
-    olderSnapshotPolicies=olderDate+ "_" + type + role + "PoliciesLZ" + LZ + ".json"
-    newerSnapshotPolicies=newerDate+ "_" + type + role + "PoliciesLZ" + LZ + ".json"   
+    olderSnapshotPolicies=olderDate+ "_" + type + role + "Policies" + "_" + LicensePlate + "_LZ" +  LZ + ".json"
+    newerSnapshotPolicies=newerDate+ "_" + type + role + "Policies" + "_" + LicensePlate + "_LZ" +  LZ + ".json"   
     
     olderSnapshotConfig=suppFunct.importJsonFile("./results/"+olderSnapshotConfig)
     newerSnapshotConfig=suppFunct.importJsonFile("./results/"+newerSnapshotConfig)
@@ -108,7 +113,7 @@ else: # Case we search in the ./results folder and the files names follow the st
     newerSnapshotPolicies=suppFunct.importJsonFile("./results/"+newerSnapshotPolicies)
 
 
-if olderSnapshotConfig["TestInformation"]["awsAccountUsed"]!=newerSnapshotConfig["TestInformation"]["awsAccountUsed"] or olderSnapshotConfig["TestInformation"]["AWS_DEFAULT_REGION"]!=newerSnapshotConfig["TestInformation"]["AWS_DEFAULT_REGION"] or olderSnapshotConfig["TestInformation"]["Landing Zone"]!=newerSnapshotConfig["TestInformation"]["Landing Zone"]:
+if olderSnapshotConfig["TestInformation"]["awsAccountUsed"]!=newerSnapshotConfig["TestInformation"]["awsAccountUsed"] or olderSnapshotConfig["TestInformation"]["AWS_DEFAULT_REGION"]!=newerSnapshotConfig["TestInformation"]["AWS_DEFAULT_REGION"] or olderSnapshotConfig["TestInformation"]["Landing Zone"]!=newerSnapshotConfig["TestInformation"]["Landing Zone"]or olderSnapshotConfig["TestInformation"]["LicensePlate"]!=newerSnapshotConfig["TestInformation"]["LicensePlate"]:
     print("You are comparing the wrong snapshots, either the account, region or Landing Zone are not the same")
     quit()
 
@@ -122,6 +127,7 @@ html=html+ "<table><tr><th></th><th>Older Snapshot</th><th>Newer Snapshot</th></
 html=html+ "<td><B>Date/Time</B></td><td>"    + olderSnapshotConfig["TestInformation"]["DateTime"]           + "</td><td>" + newerSnapshotConfig["TestInformation"]["DateTime"]           + "</td></tr>"
 html=html+ "<td><B>Account</B></td><td>"      + olderSnapshotConfig["TestInformation"]["awsAccountUsed"]     + "</td><td>" + newerSnapshotConfig["TestInformation"]["awsAccountUsed"]     + "</td></tr>"
 html=html+ "<td><B>Region</B></td><td>"       + olderSnapshotConfig["TestInformation"]["AWS_DEFAULT_REGION"] + "</td><td>" + newerSnapshotConfig["TestInformation"]["AWS_DEFAULT_REGION"] + "</td></tr>"
+html=html+ "<td><B>License Plate</B></td><td>" + olderSnapshotConfig["TestInformation"]["LicensePlate"]      + "</td><td>" + newerSnapshotConfig["TestInformation"]["LicensePlate"]       + "</td></tr>"
 html=html+ "<td><B>Landing Zone</B></td><td>" + olderSnapshotConfig["TestInformation"]["Landing Zone"]       + "</td><td>" + newerSnapshotConfig["TestInformation"]["Landing Zone"]       + "</td></tr>"
 
 html=html+ "</tr></table>"
@@ -339,6 +345,6 @@ if changeFlag==0:
 html=html+"</body>\n"
 html=html+"</head>\n"
   
-with open('./'+ olderDate + '_' + newerDate + '_' + type + role + 'LZ' + LZ +'.html', 'w') as f: #The report name is harcoded.
+with open('./'+ olderDate + '_' + newerDate + '_' + type + role + "_" + LicensePlate + "_LZ" + LZ + '.html', 'w') as f: #The report name is harcoded.
     f.write(html)
     

--- a/getSnapshot.py
+++ b/getSnapshot.py
@@ -18,7 +18,7 @@ print("by exporting them into your terminal session")
 print("############################################################################################################")
 
 print("The following questions are used to create the name of the output files in the form")
-print("YYYMMDD_<type><Role><Config/Policies><LZ#>")
+print("YYYMMDD_<type><Role><Config/Policies>_<LicensePlate>_<LZ#>")
 print("############################################################################################################")
 print("")
 
@@ -34,6 +34,12 @@ while len(userAccount)!=0 and len(userAccountSplit)<4 :
         userAccount="BCGOV_MASTER_admin_tmhl5tvs"
     userAccountSplit=userAccount.split("_")
 
+LicensePlate=""
+print("Which License Plate-environment is using the previous base account? - If enter nothing will use  \"tmhl5tvs-dev\"")
+LicensePlate=input()
+if len(LicensePlate)==0:
+    userAccount="tmhl5tvs-dev"
+    
 
 LZ=""
 while LZ not in ["0","1","2"]:
@@ -50,12 +56,12 @@ role=roleDic[userAccountSplit[2]]
 
     
 currentDate = datetime.date.today().strftime("%Y%m%d")
-resultsConfigFile=currentDate + "_" + type + role + "ConfigLZ" + LZ + ".json"
-resultsPoliciesFile=currentDate + "_" + type + role + "PoliciesLZ" + LZ + ".json"
+resultsConfigFile=currentDate + "_" + type + role + "Config" + "_" + LicensePlate + "_" + "LZ" + LZ + ".json"
+resultsPoliciesFile=currentDate + "_" + type + role + "Policies" + "_" +  LicensePlate+ "_" + "LZ" + LZ + ".json"
 
 # Notice the folder where we save the results is hardcoded
-aws_ConfigValues.awsConfigValues(userAccount,"./results/"+resultsConfigFile,LZ)
-aws_PoliciesInRoles.awsPoliciesInRoles(userAccount,"./results/"+resultsPoliciesFile,LZ)
+aws_ConfigValues.awsConfigValues(userAccount,LicensePlate,"./results/"+resultsConfigFile,LZ)
+aws_PoliciesInRoles.awsPoliciesInRoles(userAccount,LicensePlate,"./results/"+resultsPoliciesFile,LZ)
 
 print("The following files have been created in the results folder:")
 print("-" + resultsConfigFile )

--- a/suppFunct.py
+++ b/suppFunct.py
@@ -42,12 +42,13 @@ def getOutputApi(fileName,node):
         return output
 
     
-def closeResultsFile(resultsFile,awsAccountUsed,LZ):
+def closeResultsFile(resultsFile,LicensePlate,awsAccountUsed,LZ):
     with open(resultsFile, 'a') as f:
         f.write('   \"TestInformation\": ' +' {\n')
         f.write('       \"DateTime\" : "' +str(datetime.datetime.now())+ '",\n')
         f.write('       \"awsAccountUsed\" : "' + awsAccountUsed + '",\n')
         f.write('       \"AWS_DEFAULT_REGION\" : "' + os.environ.get('AWS_DEFAULT_REGION') + '",\n')
+        f.write('       \"LicensePlate\" : "' + LicensePlate + '",\n')
         f.write('       \"Landing Zone\" : \"LZ' + str(LZ) + '"\n')
         f.write('   }\n')
         f.write('}')


### PR DESCRIPTION
I realized that different accounts (defined partially by License Plate) that share the same role can have a different policies in roles profie, as different assets, like Lambda functions, may add more policies. So, when comparing the snapshots we need to compare the same account and role.